### PR TITLE
fix: JPEG fallback for gallery images on non-WebP browsers

### DIFF
--- a/app/components/DImg.vue
+++ b/app/components/DImg.vue
@@ -2,20 +2,53 @@
 withDefaults(defineProps<{
   src: string
   alt: string
+  /**
+   * Optional same-image URL in a universally-supported format (JPEG). When set,
+   * `src` is offered as a WebP `<source>` and this is the `<img>` fallback, so
+   * browsers without WebP support (older Safari, some in-app webviews) still get
+   * a picture instead of a broken image.
+   */
+  fallbackSrc?: string
   width?: string | number
   height?: string | number
   loading?: 'lazy' | 'eager'
   fetchpriority?: 'high' | 'low' | 'auto'
 }>(), {
+  fallbackSrc: undefined,
   width: undefined,
   height: undefined,
   loading: 'lazy',
   fetchpriority: 'auto',
 })
+
+// Class/style land on the <img>, not the <picture> wrapper, so existing
+// image styling keeps targeting the element it always has.
+defineOptions({ inheritAttrs: false })
 </script>
 
 <template>
+  <picture
+    v-if="fallbackSrc"
+    class="d-img-picture"
+  >
+    <source
+      :srcset="src"
+      type="image/webp"
+    >
+    <img
+      v-bind="$attrs"
+      :src="fallbackSrc"
+      :alt="alt"
+      :width="width"
+      :height="height"
+      :loading="loading"
+      :fetchpriority="fetchpriority"
+      decoding="async"
+    >
+  </picture>
   <img
+    v-else
+    v-bind="$attrs"
     :src="src"
     :alt="alt"
     :width="width"
@@ -25,3 +58,11 @@ withDefaults(defineProps<{
     decoding="async"
   >
 </template>
+
+<style>
+/* The wrapper must not generate its own box, or it would break the layout and
+   the auto-margins/aspect-ratio the inner <img> relies on. */
+.d-img-picture {
+  display: contents;
+}
+</style>

--- a/app/components/ProjectCard.vue
+++ b/app/components/ProjectCard.vue
@@ -24,6 +24,13 @@ const thumbnail = computed(() => {
   return `/thumbnails/${fileType}/${path}.${fileType}`
 })
 
+// JPEG fallback for browsers without WebP support, so the card still shows an image.
+const thumbnailFallback = computed(() => {
+  const { fallbackFileType, path } = props.project.image
+  if (!fallbackFileType) return undefined
+  return `/thumbnails/${fallbackFileType}/${path}.${fallbackFileType}`
+})
+
 const year = computed(() => {
   const end = props.project.endDate ? formatDate(props.project.endDate) : 'Present'
   return props.project.startDate ? `${formatDate(props.project.startDate)} – ${end}` : end
@@ -49,6 +56,7 @@ const to = computed(() =>
       :width="227"
       :height="227"
       :src="thumbnail"
+      :fallback-src="thumbnailFallback"
       :alt="project.title"
       :loading="eager ? 'eager' : 'lazy'"
       :fetchpriority="priority ? 'high' : 'auto'"
@@ -68,6 +76,7 @@ const to = computed(() =>
       :width="227"
       :height="227"
       :src="thumbnail"
+      :fallback-src="thumbnailFallback"
       :alt="project.title"
       :loading="eager ? 'eager' : 'lazy'"
       :fetchpriority="priority ? 'high' : 'auto'"

--- a/app/pages/gallery/[slug].vue
+++ b/app/pages/gallery/[slug].vue
@@ -21,6 +21,8 @@ const images = Array.from({ length: count }, (_, index) => {
   const src = `/galleries/${path}/${path}-${index}.webp`
   return {
     src,
+    // The original JPEG is the <img> fallback for browsers without WebP support.
+    fallbackSrc: `/galleries/${path}/${path}-${index}${gallery.images.fileType}`,
     alt: `${gallery.title} – Image ${index + 1} of ${count}`,
     // Intrinsic size reserves the box before the bytes land, which keeps CLS at zero.
     ...getImageDimensions(src),
@@ -53,6 +55,7 @@ useSeo({
         :key="image.alt"
         class="gallery-img"
         :src="image.src"
+        :fallback-src="image.fallbackSrc"
         :alt="image.alt"
         :width="image.width"
         :height="image.height"


### PR DESCRIPTION
## Summary

Reported issue: "images in most galleries aren't displaying or take forever to display."

### What I found

I rebuilt the site with the production preset (`NITRO_PRESET=static npm run generate`) and drove every gallery in a headless Chromium at desktop and mobile widths. On a WebP‑capable browser the current build is **healthy**: every gallery renders all of its images, zero broken, zero non‑200 responses, and payloads are small (136 KB–1.1 MB per gallery) thanks to the committed WebP derivatives, intrinsic `width`/`height`, and lazy loading. No slowness or broken‑image defect reproduces there.

The one real gap: gallery images and project cards emitted a bare `<img>` pointing **only** at the WebP file. A client without WebP support (older iOS Safari, some in‑app / embedded webviews) gets a broken image on *every* gallery and card — which matches "most galleries aren't displaying." The original JPEGs already sit next to every WebP, and the data model already declared them (`gallery.images.fileType`, `project.image.fallbackFileType`); the fallback was simply never wired up.

### What changed

- **`DImg.vue`** — accepts an optional `fallbackSrc`. When present it renders a `<picture>` with the WebP as a `<source type="image/webp">` and the JPEG as the `<img>` fallback. `inheritAttrs: false` + `display: contents` on the wrapper keep the class, intrinsic dimensions, lazy loading, and auto‑margins applying to the `<img>` exactly as before, so WebP‑capable browsers are unaffected.
- **`gallery/[slug].vue`** — passes the sibling JPEG as `fallback-src` for each image.
- **`ProjectCard.vue`** — derives the JPEG thumbnail from the already‑declared `fallbackFileType` and passes it as `fallback-src`.

No new assets, no build changes.

### Verification

- `npm run lint` and `npm run typecheck` pass.
- Rebuilt static output confirmed to contain the `<picture>`/`<source>`/`<img>` markup.
- Headless Chromium (WebP‑capable): all galleries + all 29 homepage cards render, 0 broken, WebP served, layout unchanged (gallery images 653px, cards square). No regression.
- Fallback path uses the standard `<picture>` format‑negotiation mechanism, so a browser lacking WebP support skips the `<source>` and loads the JPEG.

### Note

This migration (Nuxt 4 + SSG + WebP) landed only a day before this fix, and the built artifact is healthy. If the **live** site still shows broken/slow gallery images broadly, it most likely also needs to be redeployed with this build — the fix here hardens display for the non‑WebP segment on top of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019866YUvKjwjrZyYFE3TPoM)_