### PR TITLE
perf(amplify): trim build minutes on npm ci and Node install

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -10,7 +10,12 @@ frontend:
         # resolves some transitive deps differently and fails `npm ci` with
         # "Missing: cac@... from lock file". Do not drop back to Node 22.
         - nvm install # uses the version in .nvmrc
-        - npm ci
+        # --prefer-offline: install from the cached ~/.npm tarballs below instead of
+        #   revalidating every package against the registry.
+        # --no-audit: skip the vulnerability audit's network round-trip (the CI job on
+        #   GitHub already gates that); it adds latency and occasionally flakes a build.
+        # --no-fund: drop the funding-metadata output.
+        - npm ci --prefer-offline --no-audit --no-fund
     build:
       commands:
         # Amplify's build image exports NITRO_PRESET=aws-amplify, which redirects the
@@ -27,6 +32,9 @@ frontend:
       # npm's tarball cache, not node_modules. A restored node_modules can be
       # reconciled into package-lock.json, which then breaks `npm ci`.
       - ~/.npm/**/*
+      # nvm's download cache. `nvm install` reuses the cached Node 24 tarball here
+      # instead of re-fetching it from nodejs.org on every build.
+      - ~/.nvm/.cache/**/*
 
 # Amplify serves static files with a short default TTL. These override it.
 customHeaders:


### PR DESCRIPTION
## What & why

AWS Amplify Hosting is billed per build minute, so the goal is to cut wall-clock time in the build without changing the output. This PR targets the two network-bound steps in `preBuild`; the rest of the pipeline is already lean.

## Changes

- **`npm ci --prefer-offline --no-audit --no-fund`**
  - `--prefer-offline` installs from the already-cached `~/.npm` tarballs instead of revalidating every package against the registry.
  - `--no-audit` drops the vulnerability-audit network round-trip at the end of the install (which also occasionally flakes builds). Auditing/lint/typecheck are already gated by the GitHub Actions CI job.
  - `--no-fund` drops funding-metadata output.
- **Cache `~/.nvm/.cache`** so `nvm install` reuses the downloaded Node 24 tarball instead of re-fetching it from nodejs.org on every build.

## Already-optimized (left untouched)

- Lint + typecheck run in GitHub Actions, not in the Amplify build.
- `sharp`/WebP image processing runs offline by hand and never in the Amplify build.
- `~/.npm` is cached; `node_modules` is deliberately not (since `npm ci` wipes it).

## Risk

Low. No change to build output (`.output/public`), artifacts, headers, or the Node version. Cache misses degrade gracefully to current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeZNqQpsQ4QYnCVKyVCten

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeZNqQpsQ4QYnCVKyVCten)_