### PR TITLE
perf(amplify): skip nvm default global packages to halve build time

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,7 +9,15 @@ frontend:
         # lockfileVersion 3 written by npm 11; npm 10 (bundled with Node 22)
         # resolves some transitive deps differently and fails `npm ci` with
         # "Missing: cac@... from lock file". Do not drop back to Node 22.
-        - nvm install # uses the version in .nvmrc
+        #
+        # --skip-default-packages is the single biggest lever here. The Amplify
+        # build image ships an nvm default-packages file (Amplify CLI, Cypress,
+        # Hugo, VuePress, Yarn, Bower, grunt-cli). Because Node 24 is not the
+        # image's default, every build provisions a fresh 24 and nvm reinstalls
+        # all ~1690 of those globals — ~65s, two-thirds of the whole build — none
+        # of which this static Nuxt site uses. Skipping them leaves just the Node
+        # download (~8s). npm itself is bundled with Node, so nothing is lost.
+        - nvm install --skip-default-packages # uses the version in .nvmrc
         # --prefer-offline: install from the cached ~/.npm tarballs below instead of
         #   revalidating every package against the registry.
         # --no-audit: skip the vulnerability audit's network round-trip (the CI job on


### PR DESCRIPTION
## What & why

The build-config tweaks in #3 optimized the wrong phase — the Amplify build log revealed the real bottleneck. Of a ~98s logged build, **~65s (two-thirds) is nvm reinstalling global packages this site never uses.**

From the build log:
```
Installing default global packages from /root/.nvm/default-packages...
npm install -g @aws-amplify/cli bower cypress grunt-cli hugo-extended vuepress yarn
→ added 1690 packages in 1m
```

Amplify's build image ships an nvm `default-packages` file. Because Node 24 isn't the image's default, every build provisions a fresh Node 24 and nvm reinstalls all 1690 of those globals (Amplify CLI, Cypress, Hugo, VuePress, Yarn, Bower, grunt-cli). This static Nuxt site uses none of them — `npm` itself is bundled with Node.

## Change

`nvm install` → `nvm install --skip-default-packages`

That flag is documented as *"When installing, skip the default-packages file if it exists."* Only Node itself is fetched (~8s), so the preBuild phase drops from ~73s to ~17s.

## Measured phase breakdown (Deployment 10 log)

| Phase | Before |
|---|---|
| Provision + clone | ~6s |
| nvm — Node 24 download | ~8s |
| **nvm — default global packages** | **~65s ← eliminated** |
| `npm ci` (project deps) | ~9s |
| `nuxt generate` | ~8s |
| Cache + artifact upload | ~2s |

Expected result: the billed build drops from ~2m13s to roughly ~1m.

## Risk

Low. The skipped globals (Amplify CLI, Cypress, Hugo, VuePress, Yarn, Bower, grunt-cli) are unrelated to `npm ci` and `nuxt generate`; `npm` ships with Node. No change to build output, artifacts, headers, or the Node version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeZNqQpsQ4QYnCVKyVCten

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeZNqQpsQ4QYnCVKyVCten)_